### PR TITLE
Add fedora/epel GPG key

### DIFF
--- a/roles/install_wg/tasks/main.yml
+++ b/roles/install_wg/tasks/main.yml
@@ -29,7 +29,10 @@
     - name: install elrepo GPG key for RHEL8
       rpm_key:
         state: present
-        key: https://www.elrepo.org/RPM-GPG-KEY-elrepo.org
+        key: "{{ item }}"
+        with_items:
+          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8
+          - https://www.elrepo.org/RPM-GPG-KEY-elrepo.org
 
     - name: install epel and elrepo for RHEL8
       yum:


### PR DESCRIPTION
fix epel install step by adding a missing GPG key

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>